### PR TITLE
fix: add CORS middleware

### DIFF
--- a/deployment/kubernetes/geocoder-api.yaml
+++ b/deployment/kubernetes/geocoder-api.yaml
@@ -55,6 +55,19 @@ spec:
     forceSlash: true
 ---
 apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: cors-geocoder
+spec:
+  headers:
+    accessControlAllowMethods:
+      - "GET"
+    accessControlAllowHeaders:
+      - "*"
+    accessControlAllowOriginList:
+      - "*"
+---
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: geocoder-api
@@ -70,3 +83,4 @@ spec:
       port: 80
     middlewares:
     - name: stripprefix-geocoding
+    - name: cors-geocoder


### PR DESCRIPTION
Adds a middleware for CORS handling. This allows webpages to make requests without having a server.